### PR TITLE
change after sign out path, propagate login status to JS

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -177,7 +177,7 @@ protected
   # @return [String] URL to redirect to
   #
   def after_sign_out_path_for(resource_or_scope)
-    home_path
+    contributor_dashboard_path
   end
 
   ##

--- a/app/views/themes/v2.1/layouts/_links.html.erb
+++ b/app/views/themes/v2.1/layouts/_links.html.erb
@@ -58,8 +58,5 @@
 <%= link.html_safe %>
 
 <link href="http://styleguide.europeana.eu/css/e7a_1418/screen.css" media="all" rel="stylesheet" type="text/css">
-<script type="text/javascript">
-  var userLoggedIn=<%= current_user.role.name != 'guest' ? 'true' : 'false' %>
-  
-</script>
+<script type="text/javascript">var userLoggedIn=<%= current_user.role.name != 'guest' ? 'true' : 'false' %></script>
 <script src="http://styleguide.europeana.eu/js/modules/eu/e7a_1418_iframe.js" type="text/javascript"></script>

--- a/app/views/themes/v2.1/layouts/_links.html.erb
+++ b/app/views/themes/v2.1/layouts/_links.html.erb
@@ -58,4 +58,8 @@
 <%= link.html_safe %>
 
 <link href="http://styleguide.europeana.eu/css/e7a_1418/screen.css" media="all" rel="stylesheet" type="text/css">
+<script type="text/javascript">
+  var userLoggedIn=false;
+  <%- if current_user.role.name != 'guest' -%>userLoggedIn=true;<%- end -%>
+</script>
 <script src="http://styleguide.europeana.eu/js/modules/eu/e7a_1418_iframe.js" type="text/javascript"></script>

--- a/app/views/themes/v2.1/layouts/_links.html.erb
+++ b/app/views/themes/v2.1/layouts/_links.html.erb
@@ -58,5 +58,5 @@
 <%= link.html_safe %>
 
 <link href="http://styleguide.europeana.eu/css/e7a_1418/screen.css" media="all" rel="stylesheet" type="text/css">
-<script type="text/javascript">var userLoggedIn=<%= current_user.role.name != 'guest' ? 'true' : 'false' %></script>
+<script type="text/javascript">var userLoggedIn=<%= current_user.role.name != 'guest' ? 'true' : 'false' %>;</script>
 <script src="http://styleguide.europeana.eu/js/modules/eu/e7a_1418_iframe.js" type="text/javascript"></script>

--- a/app/views/themes/v2.1/layouts/_links.html.erb
+++ b/app/views/themes/v2.1/layouts/_links.html.erb
@@ -59,7 +59,7 @@
 
 <link href="http://styleguide.europeana.eu/css/e7a_1418/screen.css" media="all" rel="stylesheet" type="text/css">
 <script type="text/javascript">
-  var userLoggedIn=false;
-  <%- if current_user.role.name != 'guest' -%>userLoggedIn=true;<%- end -%>
+  var userLoggedIn=<%= current_user.role.name != 'guest' ? 'true' : 'false' %>
+  
 </script>
 <script src="http://styleguide.europeana.eu/js/modules/eu/e7a_1418_iframe.js" type="text/javascript"></script>


### PR DESCRIPTION
PR to change the after sign out path to prevent the embedded 14-18 app from redirecting to it's homepage, which isn't supposed to be shown in the portal's iframe.

Also a small javascript snippet to help notify the portal about the users sign-in status.