### PR TITLE
Store EDM RDF/XML metadata mapping

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -417,7 +417,7 @@ class ContributionsController < ApplicationController
         when :nt
           contribution.edm.to_ntriples
         when :xml
-          contribution.edm.to_rdfxml
+          contribution.to_rdfxml
       end
       write_fragment(cache_key, data.to_yaml)
     end

--- a/app/jobs/edm_metadata_mapping_job.rb
+++ b/app/jobs/edm_metadata_mapping_job.rb
@@ -1,0 +1,17 @@
+##
+# Job to generate and store EDM metadata mapping for a contribution
+class EDMMetadataMappingJob
+  def initialize(contribution_id)
+    @contribution_id = contribution_id
+  end
+  
+  def perform
+    mapping = MetadataMapping.where(:mappable_type => 'Contribution', :mappable_id => contribution.id, :format => 'edm_rdfxml').first_or_initialize
+    mapping.content = contribution.edm.to_rdfxml
+    mapping.save
+  end
+
+  def contribution
+    @contribution ||= Contribution.find(@contribution_id)
+  end
+end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -386,6 +386,11 @@ class Contribution < ActiveRecord::Base
     attachments.all?(&:has_rich_metadata?)
   end
 
+  def to_rdfxml
+    mapping = mappings.where(:format => 'edm_rdfxml').first
+    mapping.nil? ? edm.to_rdfxml : mapping.content
+  end
+
 protected
 
   def build_metadata_unless_present

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -17,6 +17,7 @@ class Contribution < ActiveRecord::Base
   belongs_to :contributor, :class_name => 'User'
   belongs_to :cataloguer, :class_name => 'User', :foreign_key => 'catalogued_by'
   belongs_to :metadata, :class_name => 'MetadataRecord', :foreign_key => 'metadata_record_id', :dependent => :destroy
+  has_many :mappings, :class_name => 'MetadataMapping', :as => :mappable
   #--
   # @fixme: Destroy associated contact when contribution destroyed, 
   # *IF* this is a guest contribution, *AND* there are no other associated 

--- a/app/models/europeana/oai/contribution_record.rb
+++ b/app/models/europeana/oai/contribution_record.rb
@@ -120,7 +120,7 @@ module Europeana
       end
       
       def to_oai_edm
-        edm.to_rdfxml.sub(/<\?xml .*? ?>/, "")
+        to_rdfxml.sub(/<\?xml .*? ?>/, "")
       end
     end
   end

--- a/app/models/metadata_mapping.rb
+++ b/app/models/metadata_mapping.rb
@@ -1,0 +1,6 @@
+class MetadataMapping < ActiveRecord::Base
+  belongs_to :mappable, :polymorphic => true
+
+  validates :mappable, :format, :content, :presence => true
+  validates :format, :uniqueness => { scope: [:mappable_id, :mappable_type] }
+end

--- a/app/models/metadata_mapping_observer.rb
+++ b/app/models/metadata_mapping_observer.rb
@@ -1,0 +1,26 @@
+##
+# Observer to (re)generate EDM mapping for contributions when they, or their
+# attachments or contributor are updated.
+class MetadataMappingObserver < ActiveRecord::Observer
+  observe :contribution, :attachment, :user
+
+  def after_save(model)
+    case model
+    when Contribution
+      queue_job_for_contribution(model)
+    when Attachment
+      queue_job_for_contribution(model.contribution)
+    when User
+      model.contributions.find_each do |contribution|
+        queue_job_for_contribution(contribution)
+      end
+    end
+  end
+
+protected
+
+  def queue_job_for_contribution(contribution)
+    return unless contribution.published?
+    Delayed::Job.enqueue EDMMetadataMappingJob.new(contribution), :queue => 'mapping'
+  end
+end

--- a/app/models/metadata_mapping_observer.rb
+++ b/app/models/metadata_mapping_observer.rb
@@ -2,22 +2,34 @@
 # Observer to (re)generate EDM mapping for contributions when they, or their
 # attachments or contributor are updated.
 class MetadataMappingObserver < ActiveRecord::Observer
-  observe :contribution, :attachment, :user
+  observe :contribution, :attachment, :metadata_record, :user
 
   def after_save(model)
-    case model
-    when Contribution
-      queue_job_for_contribution(model)
-    when Attachment
-      queue_job_for_contribution(model.contribution)
-    when User
-      model.contributions.find_each do |contribution|
+    subject = contribution_from_observed_model(model)
+
+    if subject.respond_to?(:find_each)
+      subject.find_each do |contribution|
         queue_job_for_contribution(contribution)
       end
+    else
+      queue_job_for_contribution(subject)
     end
   end
 
 protected
+
+  def contribution_from_observed_model(model)
+    case model
+    when Contribution
+      model
+    when Attachment
+      model.contribution
+    when MetadataRecord
+      model.contribution.present? ? model.contribution : model.attachment.contribution
+    when User
+      model.contributions
+    end
+  end
 
   def queue_job_for_contribution(contribution)
     return unless contribution.published?

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module RunCoCo
     # Activate observers that should always be running.
     # config.active_record.observers = "AttachmentSweeper", "ContactSweeper",
     #   "ContributionSweeper"
+    config.active_record.observers = :metadata_mapping_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/db/migrate/20170606075207_create_metadata_mappings.rb
+++ b/db/migrate/20170606075207_create_metadata_mappings.rb
@@ -1,0 +1,11 @@
+class CreateMetadataMappings < ActiveRecord::Migration
+  def change
+    create_table :metadata_mappings do |t|
+      t.references :mappable, :polymorphic => true
+      t.string :format
+      t.text :content, :limit => 16.megabytes - 1
+      t.timestamps
+    end
+    add_index :metadata_mappings, [:mappable_id, :mappable_type]
+  end
+end

--- a/db/schema-example.rb
+++ b/db/schema-example.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140514120850) do
+ActiveRecord::Schema.define(:version => 20170606075207) do
 
   create_table "annotation_shapes", :force => true do |t|
     t.integer  "annotation_id"
@@ -25,14 +25,16 @@ ActiveRecord::Schema.define(:version => 20140514120850) do
   add_index "annotation_shapes", ["annotation_id"], :name => "index_annotation_shapes_on_annotation_id"
 
   create_table "annotations", :force => true do |t|
-    t.integer  "attachment_id"
+    t.integer  "annotatable_id"
     t.integer  "user_id"
     t.text     "text"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "src"
+    t.text     "annotatable_type"
   end
 
-  add_index "annotations", ["attachment_id"], :name => "index_annotations_on_attachment_id"
+  add_index "annotations", ["annotatable_id"], :name => "index_annotations_on_attachment_id"
   add_index "annotations", ["user_id"], :name => "index_annotations_on_user_id"
 
   create_table "attachments", :force => true do |t|
@@ -66,6 +68,8 @@ ActiveRecord::Schema.define(:version => 20140514120850) do
     t.string   "image_content_type"
     t.integer  "image_file_size"
     t.datetime "image_updated_at"
+    t.string   "map_latlng"
+    t.integer  "map_zoom"
   end
 
   add_index "collection_days", ["contact_id"], :name => "index_collection_days_on_contact_id"
@@ -102,6 +106,18 @@ ActiveRecord::Schema.define(:version => 20140514120850) do
   add_index "contributions", ["contributor_id"], :name => "index_contributions_on_contributor_id"
   add_index "contributions", ["guest_id"], :name => "index_contributions_on_guest_id"
   add_index "contributions", ["metadata_record_id"], :name => "index_contributions_on_metadata_record_id"
+
+  create_table "current_statuses", :force => true do |t|
+    t.integer  "record_id"
+    t.string   "record_type"
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "current_statuses", ["name"], :name => "index_current_statuses_on_name"
+  add_index "current_statuses", ["record_id"], :name => "index_current_statuses_on_record_id"
+  add_index "current_statuses", ["record_type"], :name => "index_current_statuses_on_record_type"
 
   create_table "delayed_jobs", :force => true do |t|
     t.integer  "priority",   :default => 0, :null => false
@@ -173,6 +189,17 @@ ActiveRecord::Schema.define(:version => 20140514120850) do
     t.boolean  "attachment",      :default => true,  :null => false
     t.boolean  "facet",           :default => false, :null => false
   end
+
+  create_table "metadata_mappings", :force => true do |t|
+    t.integer  "mappable_id"
+    t.string   "mappable_type"
+    t.string   "format"
+    t.text     "content",       :limit => 16777215
+    t.datetime "created_at",                        :null => false
+    t.datetime "updated_at",                        :null => false
+  end
+
+  add_index "metadata_mappings", ["mappable_id", "mappable_type"], :name => "index_metadata_mappings_on_mappable_id_and_mappable_type"
 
   create_table "metadata_records", :force => true do |t|
     t.datetime "created_at"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,18 @@ services:
       - ..:/app
     environment:
       DATABASE_URL: mysql2://1418:1418pass@db/europeana_1418?utf8=true
+  worker:
+    image: 1418-worker
+    build:
+      context: ./worker
+    depends_on:
+      - db
+    links:
+      - db
+    volumes:
+    - ..:/app
+    environment:
+      DATABASE_URL: mysql2://1418:1418pass@db/europeana_1418?utf8=true
   db:
     image: 1418-db
     build:

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,0 +1,4 @@
+FROM 1418-web
+
+CMD bundle install --system --full-index && \
+  bundle exec script/delayed_job run

--- a/lib/europeana/oai/metadata_format.rb
+++ b/lib/europeana/oai/metadata_format.rb
@@ -48,7 +48,7 @@ module Europeana
         
         def header_specification
           {
-            'xmlns:oai_europeana19141918' => @namespace,
+            'xmlns:oai_edm' => @namespace,
             'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
             'xsi:schemaLocation' => @namespace + ' ' + @schema
           }

--- a/lib/tasks/mappings.rake
+++ b/lib/tasks/mappings.rake
@@ -1,7 +1,7 @@
 namespace :mappings do
   desc "Generate EDM RDF/XML for all contributions, via DJ."
   task :edm_rdfxml => :environment do
-    Contribution.pluck(:id).each do |contribution_id|
+    Contribution.published.pluck(:id).each do |contribution_id|
       Delayed::Job.enqueue EDMMetadataMappingJob.new(contribution_id), :queue => 'mapping'
     end
   end

--- a/lib/tasks/mappings.rake
+++ b/lib/tasks/mappings.rake
@@ -1,0 +1,8 @@
+namespace :mappings do
+  desc "Generate EDM RDF/XML for all contributions, via DJ."
+  task :edm_rdfxml => :environment do
+    Contribution.pluck(:id).each do |contribution_id|
+      Delayed::Job.enqueue EDMMetadataMappingJob.new(contribution_id), :queue => 'mapping'
+    end
+  end
+end


### PR DESCRIPTION
Re: https://europeanadev.assembla.com/spaces/europeana-npc/tickets/2225

* Adds a new db-stored model `MetadataMapping`, storing generated mapped content
* Adds a job `EDMMetadataMappingJob` generating EDM RDF/XML for a contribution and storing it in the db
* Adds a Rake task `mappings:edm_rdfxml` queueing the above job for all published contributions
* Adds an observer `MetadataMappingObserver` to regenerate stored EDM RDF/XML when a contribution or one of its attachments or contributor records change
* Adapts the OAI-PMH provider to use the stored EDM RDF/XML when available
* Adds Delayed Job worker image to Docker